### PR TITLE
Accept link attributes without quote such as rel=next

### DIFF
--- a/lib/link_header.rb
+++ b/lib/link_header.rb
@@ -91,8 +91,8 @@ class LinkHeader
       href = scanner[1]
       attrs = []
       while scanner.scan(ATTR)
-        attr_name, token, quoted = scanner[1], scanner[3], scanner[4].gsub(/\\"/, '"')
-        attrs.push([attr_name, token || quoted])
+        attr_name, token, quoted = scanner[1], scanner[3], scanner[4]
+        attrs.push([attr_name, token || quoted.gsub(/\\"/, '"')])
         break unless scanner.scan(SEMI)
       end
       links.push(Link.new(href, attrs))

--- a/test/test_link_header.rb
+++ b/test/test_link_header.rb
@@ -58,7 +58,13 @@ class TestLinkHeader < Test::Unit::TestCase
   def test_link_header_to_s
     assert_equal(LINK_HEADER_S, LinkHeader.new(LINK_HEADER_A).to_s)
   end
-  
+
+  def test_parse_token
+    link = LinkHeader.parse('</foo>; rel=self').links[0]
+    assert_equal("/foo", link.href)
+    assert_equal([["rel", "self"]], link.attr_pairs)
+  end
+
   def test_parse_href
     assert_equal("any old stuff!", LinkHeader.parse('<any old stuff!>').links[0].href)
   end


### PR DESCRIPTION
The scanner was already setup to match the pattern, but there's an unnecessary gsub call in case of the match and caused runtime error such as:

```
> LinkHeader.parse('</path>; rel=next')
NoMethodError: undefined method `gsub' for nil:NilClass
       from {...}lib/ruby/gems/2.0.0/gems/link_header-0.0.7/lib/link_header.rb:94:in `parse'
```

This patch moves the gsub to only run in case of quoted match.
