### PR TITLE
Relax bundler requirement, add required test dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in link_header.gemspec
+# Pull in dependencies from gemspec
 gemspec
+
+# Load additional development dependencies
+gem 'rake'
+gem 'test-unit'

--- a/link_header.gemspec
+++ b/link_header.gemspec
@@ -17,7 +17,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Not sure how maintained the gem is at this point, but -- to run the tests on ruby 3.3.x I think something like this is needed (the bundler from the gemspec is old, test-unit was turned into a bundled gem at some point, etc)