### PR TITLE
Gemspec cleanup and ruby version minimum bump

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,10 +16,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.4'
-          - '2.5'
-          - '2.6'
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Set minimum ruby version of 3.0.0
+
 ## [0.0.8] - 2013-12-04
 
 ### Added

--- a/lib/link_header/version.rb
+++ b/lib/link_header/version.rb
@@ -1,3 +1,4 @@
 class LinkHeader
-  VERSION = "0.0.8"
+  MINIMUM_RUBY_VERSION = ">= 3.0.0".freeze
+  VERSION = "0.0.8".freeze
 end

--- a/link_header.gemspec
+++ b/link_header.gemspec
@@ -1,18 +1,20 @@
 require_relative "lib/link_header/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "link_header"
-  spec.version       = LinkHeader::VERSION
+  spec.name = "link_header"
+  spec.version = LinkHeader::VERSION
   spec.required_ruby_version = LinkHeader::MINIMUM_RUBY_VERSION
-  spec.authors       = ["Mike Burrows"]
-  spec.email         = ["mjb@asplake.co.uk"]
+  spec.authors = ["Mike Burrows"]
+  spec.email = ["mjb@asplake.co.uk"]
+  spec.homepage = "https://github.com/asplake/link_header"
+
   spec.summary = "Process HTTP/HTML Web Linking data"
   spec.description = <<~DESC
-  Converts conforming link headers (and HTML link elements) to and from text,
-  LinkHeader objects and corresponding (JSON-friendly) Array representations.
+    Converts conforming link headers (and HTML link elements) to and from text,
+    LinkHeader objects and corresponding (JSON-friendly) Array representations.
   DESC
-  spec.homepage      = "https://github.com/asplake/link_header"
-  spec.license       = "MIT"
+
+  spec.license = "MIT"
 
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "https://github.com/asplake/link_header/blob/main/CHANGELOG.md"
@@ -21,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{lib}/**/*", "LICENSE", "Rakefile", "*.md"]
   end
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 end

--- a/link_header.gemspec
+++ b/link_header.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/asplake/link_header"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    Dir["{lib}/**/*", "LICENSE", "Rakefile", "*.md"]
+  end
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]

--- a/link_header.gemspec
+++ b/link_header.gemspec
@@ -14,6 +14,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/asplake/link_header"
   spec.license       = "MIT"
 
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "https://github.com/asplake/link_header/blob/main/CHANGELOG.md"
+  spec.metadata["wiki_uri"] = "https://github.com/asplake/link_header/wiki"
+
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{lib}/**/*", "LICENSE", "Rakefile", "*.md"]
   end

--- a/link_header.gemspec
+++ b/link_header.gemspec
@@ -3,6 +3,7 @@ require_relative "lib/link_header/version"
 Gem::Specification.new do |spec|
   spec.name          = "link_header"
   spec.version       = LinkHeader::VERSION
+  spec.required_ruby_version = LinkHeader::MINIMUM_RUBY_VERSION
   spec.authors       = ["Mike Burrows"]
   spec.email         = ["mjb@asplake.co.uk"]
   spec.summary = "Process HTTP/HTML Web Linking data"

--- a/link_header.gemspec
+++ b/link_header.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'link_header/version'

--- a/link_header.gemspec
+++ b/link_header.gemspec
@@ -7,8 +7,11 @@ Gem::Specification.new do |spec|
   spec.version       = LinkHeader::VERSION
   spec.authors       = ["Mike Burrows"]
   spec.email         = ["mjb@asplake.co.uk"]
-  spec.description   = %q{Converts conforming link headers to and from text, LinkHeader objects and corresponding (JSON-friendly) Array representations, also HTML link elements.}
-  spec.summary       = spec.description
+  spec.summary = "Process HTTP/HTML Web Linking data"
+  spec.description = <<~DESC
+  Converts conforming link headers (and HTML link elements) to and from text,
+  LinkHeader objects and corresponding (JSON-friendly) Array representations.
+  DESC
   spec.homepage      = "https://github.com/asplake/link_header"
   spec.license       = "MIT"
 

--- a/link_header.gemspec
+++ b/link_header.gemspec
@@ -1,6 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'link_header/version'
+require_relative "lib/link_header/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "link_header"


### PR DESCRIPTION
Various changes:

- Once over on gemspec to fix any errors/warning from `gem build` process
- Update minimum required ruby version to 3.0 (currently EOL, but reasonable cut-off)