### PR TITLE
Expand `to_html` method coverage

### DIFF
--- a/lib/link_header.rb
+++ b/lib/link_header.rb
@@ -208,7 +208,7 @@ class LinkHeader
     #   #=> '<http://example.com/foo>; rel="self"'
     #
     def to_s
-      (["<#{href}>"] + attr_pairs.map { |k, v| "#{k}=\"#{v.gsub('"', '\"')}\"" }).join("; ")
+      (["<#{href}>"] + escaped_attr_pairs).join("; ")
     end
 
     #
@@ -219,7 +219,13 @@ class LinkHeader
     #   ).to_html
     #   #=> '<link href="http://example.com/foo" rel="self">'
     def to_html
-      ([%(<link href="#{href}")] + attr_pairs.map { |k, v| "#{k}=\"#{v.gsub('"', '\"')}\"" }).join(" ") + ">"
+      ([%(<link href="#{href}")] + escaped_attr_pairs).join(" ") + ">"
+    end
+
+    private
+
+    def escaped_attr_pairs
+      attr_pairs.map { |k, v| "#{k}=\"#{v.gsub('"', '\"')}\"" }
     end
   end
 end

--- a/lib/link_header.rb
+++ b/lib/link_header.rb
@@ -41,7 +41,9 @@ class LinkHeader
   #
   # Convert to a JSON-friendly array
   #
-  #   LinkHeader.parse('<http://example.com/foo>; rel="self", <http://example.com/>; rel = "up"').to_a
+  #   LinkHeader.parse(
+  #     '<http://example.com/foo>; rel="self", <http://example.com/>; rel = "up"'
+  #   ).to_a
   #   #=> [["http://example.com/foo", [["rel", "self"]]],
   #        ["http://example.com/", [["rel", "up"]]]]
   #
@@ -54,7 +56,8 @@ class LinkHeader
   #
   #   LinkHeader.new([
   #     ["http://example.com/foo", [["rel", "self"]]],
-  #     ["http://example.com/",    [["rel", "up"]]]]).to_s
+  #     ["http://example.com/",    [["rel", "up"]]]
+  #   ]).to_s
   #   #=> '<http://example.com/foo>; rel="self", <http://example.com/>; rel = "up"'
   #
   def to_s
@@ -76,7 +79,9 @@ class LinkHeader
   #
   # Parse a link header, returning a new LinkHeader object
   #
-  #   LinkHeader.parse('<http://example.com/foo>; rel="self", <http://example.com/>; rel = "up"').to_a
+  #   LinkHeader.parse(
+  #     '<http://example.com/foo>; rel="self", <http://example.com/>; rel = "up"'
+  #   ).to_a
   #   #=> [["http://example.com/foo", [["rel", "self"]]],
   #        ["http://example.com/", [["rel", "up"]]]]
   #

--- a/lib/link_header.rb
+++ b/lib/link_header.rb
@@ -50,7 +50,7 @@ class LinkHeader
   #        ["http://example.com/", [["rel", "up"]]]]
   #
   def to_a
-    links.map { |l| l.to_a }
+    links.map(&:to_a)
   end
 
   #

--- a/lib/link_header.rb
+++ b/lib/link_header.rb
@@ -30,11 +30,7 @@ class LinkHeader
   # See also LinkHeader.parse
   #
   def initialize(links = [])
-    @links = if links
-      links.map { |l| l.is_a?(Link) ? l : Link.new(*l) }
-    else
-      []
-    end
+    @links = Array(links).map { |link| link.is_a?(Link) ? link : Link.new(*link) }
   end
 
   def <<(link)

--- a/test/link_header/link_test.rb
+++ b/test/link_header/link_test.rb
@@ -15,6 +15,10 @@ class LinkHeader::LinkTest < Test::Unit::TestCase
     assert_equal('<http://example.com/>; rel="up"; meta="bar"', link_header_link.to_s)
   end
 
+  def test_to_html
+    assert_equal('<link href="http://example.com/" rel="up" meta="bar">', link_header_link.to_html)
+  end
+
   def test_hash_key_access
     assert_equal("up", link_header_link["rel"])
   end

--- a/test/link_header/link_test.rb
+++ b/test/link_header/link_test.rb
@@ -19,6 +19,11 @@ class LinkHeader::LinkTest < Test::Unit::TestCase
     assert_equal('<link href="http://example.com/" rel="up" meta="bar">', link_header_link.to_html)
   end
 
+  def test_to_html_with_escaping
+    link = LinkHeader::Link.new("http://example.com/", [["context", 'using "scare quotes" sometimes!']])
+    assert_equal('<link href="http://example.com/" context="using \"scare quotes\" sometimes!">', link.to_html)
+  end
+
   def test_hash_key_access
     assert_equal("up", link_header_link["rel"])
   end

--- a/test/link_header_test.rb
+++ b/test/link_header_test.rb
@@ -20,8 +20,6 @@ class LinkHeaderTest < Test::Unit::TestCase
     '<link href="http://example.com/">'
   ].freeze
 
-  LINK_HEADER_HTML = LINK_HEADER_HTML_ARRAY.join("\n").freeze
-
   def test_initialization
     assert_equal(LINK_HEADER_ARRAY.length, link_header_from_array.links.length)
 
@@ -72,7 +70,11 @@ class LinkHeaderTest < Test::Unit::TestCase
   end
 
   def test_to_html
-    assert_equal(LINK_HEADER_HTML, link_header_from_array.to_html)
+    assert_equal(LINK_HEADER_HTML_ARRAY.join("\n"), link_header_from_array.to_html)
+  end
+
+  def test_to_html_with_separator
+    assert_equal(LINK_HEADER_HTML_ARRAY.join("🔗"), link_header_from_array.to_html("🔗"))
   end
 
   def test_array_push


### PR DESCRIPTION
Adds:

- Coverage for custom html separator option for `LinkHeader`
- Coverage for `Link#to_html` (this had implicit coverage from the top level class tests, but not narrow coverage for itself)
- Extract private method for repeated attr-escape code
- Misc style/naming tweaks, a few more docs/examples changes