### PR TITLE
Add `Link==` method for comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add `==` method to `LinkHeader::Link` class (compares href and attrs)
+
 ### Changed
 
 - Set minimum ruby version of 3.0.0

--- a/lib/link_header.rb
+++ b/lib/link_header.rb
@@ -223,6 +223,15 @@ class LinkHeader
       ([%(<link href="#{href}")] + escaped_attr_pairs).join(" ") + ">"
     end
 
+    #
+    # Check equality of href and attr pairs values
+    #
+    def ==(other)
+      self.class == other.class &&
+        href == other.href &&
+        attr_pairs.sort == other.attr_pairs.sort
+    end
+
     private
 
     def escaped_attr_pairs

--- a/test/link_header/link_test.rb
+++ b/test/link_header/link_test.rb
@@ -1,39 +1,49 @@
 require_relative "../test_helper"
 
-class LinkHeader::LinkTest < Test::Unit::TestCase
+class LinkHeader::LinkTest < UnitTest
   def test_initialization
-    assert_equal("http://example.com/", link_header_link.href)
-    assert_equal([%w[rel up], %w[meta bar]], link_header_link.attr_pairs)
-    assert_equal({"rel" => "up", "meta" => "bar"}, link_header_link.attrs)
+    assert_equal("http://example.com/", build_link.href)
+    assert_equal([%w[rel up], %w[meta bar]], build_link.attr_pairs)
+    assert_equal({"rel" => "up", "meta" => "bar"}, build_link.attrs)
   end
 
   def test_to_a
-    assert_equal(["http://example.com/", [%w[rel up], %w[meta bar]]], link_header_link.to_a)
+    assert_equal(["http://example.com/", [%w[rel up], %w[meta bar]]], build_link.to_a)
   end
 
   def test_to_s
-    assert_equal('<http://example.com/>; rel="up"; meta="bar"', link_header_link.to_s)
+    assert_equal('<http://example.com/>; rel="up"; meta="bar"', build_link.to_s)
   end
 
   def test_to_html
-    assert_equal('<link href="http://example.com/" rel="up" meta="bar">', link_header_link.to_html)
+    assert_equal('<link href="http://example.com/" rel="up" meta="bar">', build_link.to_html)
   end
 
   def test_to_html_with_escaping
-    link = LinkHeader::Link.new("http://example.com/", [["context", 'using "scare quotes" sometimes!']])
+    link = build_link(
+      attrs: [["context", 'using "scare quotes" sometimes!']]
+    )
     assert_equal('<link href="http://example.com/" context="using \"scare quotes\" sometimes!">', link.to_html)
   end
 
   def test_hash_key_access
-    assert_equal("up", link_header_link["rel"])
+    assert_equal("up", build_link["rel"])
   end
 
-  private
-
-  def link_header_link
-    @link_header_link ||= LinkHeader::Link.new(
-      "http://example.com/",
-      [%w[rel up], %w[meta bar]]
+  def test_equals
+    reference = build_link(
+      attrs: [%w[meta plus], %w[rel up]]
     )
+    reordered = build_link(
+      attrs: [%w[rel up], %w[meta plus]]
+    )
+    attr_different = build_link(
+      attrs: [%w[rel down]]
+    )
+    wrong_class = {}
+
+    assert_equal reference, reordered
+    assert_not_equal reference, attr_different
+    assert_not_equal reference, wrong_class
   end
 end

--- a/test/link_header_test.rb
+++ b/test/link_header_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class LinkHeaderTest < Test::Unit::TestCase
+class LinkHeaderTest < UnitTest
   LINK_HEADER_STRING_ARRAY = [
     '<http://example.com/>; rel="up"; meta="bar"',
     '<http://example.com/foo>; rel="self"',
@@ -69,8 +69,7 @@ class LinkHeaderTest < Test::Unit::TestCase
   end
 
   def test_find_link
-    link_header = link_header_from_array
-    assert_equal([%w[rel self]], link_header.find_link(%w[rel self]).attr_pairs)
+    assert_equal link_header_from_array.links[1], link_header_from_array.find_link(%w[rel self])
   end
 
   def test_to_html
@@ -82,21 +81,21 @@ class LinkHeaderTest < Test::Unit::TestCase
   end
 
   def test_array_push_with_link
-    links = LinkHeader.new
-    assert_equal([], links.to_a)
+    link_headers = LinkHeader.new
+    link = build_link
 
-    link = LinkHeader::Link.new("http://example.com/foo", [%w[rel self]])
-    links << link
-    assert_equal(link.to_a, links.to_a.first)
+    link_headers << link
+
+    assert_equal(link, link_headers.links.first)
   end
 
   def test_array_push_with_value
-    links = LinkHeader.new
-    assert_equal([], links.to_a)
+    link_headers = LinkHeader.new
+    link = build_link
 
-    link = LinkHeader::Link.new("http://example.com/foo", [%w[rel self]])
-    links << ["http://example.com/foo", [%w[rel self]]]
-    assert_equal(link.to_a, links.to_a.first)
+    link_headers << ["http://example.com/", [%w[rel up], %w[meta bar]]]
+
+    assert_equal(link, link_headers.links.first)
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,3 +7,11 @@ end
 require "stringio"
 require "test/unit"
 require File.dirname(__FILE__) + "/../lib/link_header"
+
+class UnitTest < Test::Unit::TestCase
+  protected
+
+  def build_link(href: "http://example.com/", attrs: [%w[rel up], %w[meta bar]])
+    LinkHeader::Link.new(href, attrs)
+  end
+end


### PR DESCRIPTION
Adds basic equality check for links, updates some tests to use this equality method instead of comparing other attributes of the link.